### PR TITLE
Add unit tests for all React components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15769,16 +15769,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/src/__tests__/components/Friend.test.js
+++ b/src/__tests__/components/Friend.test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Friend from '../../components/Friend';
+
+const mockFriend = { id: 2, name: 'Alice Smith' };
+
+function renderFriend(friend = mockFriend) {
+  return render(
+    <MemoryRouter>
+      <Friend friend={friend} />
+    </MemoryRouter>
+  );
+}
+
+describe('Friend', () => {
+  it('renders the friend name', () => {
+    renderFriend();
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+  });
+
+  it('links to /friend/:id using the friend id', () => {
+    renderFriend();
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/friend/2');
+  });
+
+  it('applies the friendsPage CSS class to the link', () => {
+    renderFriend();
+    expect(screen.getByRole('link')).toHaveClass('friendsPage');
+  });
+
+  it('renders inside a list group item', () => {
+    const { container } = renderFriend();
+    expect(container.querySelector('.list-group-item')).toBeInTheDocument();
+  });
+
+  it('renders a different friend correctly', () => {
+    renderFriend({ id: 99, name: 'Bob Jones' });
+    expect(screen.getByText('Bob Jones')).toBeInTheDocument();
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/friend/99');
+  });
+});

--- a/src/__tests__/components/FriendsList.test.js
+++ b/src/__tests__/components/FriendsList.test.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import FriendsList from '../../components/FriendsList';
+
+const mockUsers = [
+  { id: 2, name: 'Alice Smith' },
+  { id: 3, name: 'Bob Jones' },
+];
+
+function renderList() {
+  return render(
+    <MemoryRouter>
+      <FriendsList />
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ json: () => Promise.resolve(mockUsers) })
+  );
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('FriendsList — fetching', () => {
+  it('fetches from /users?id_ne=1 on mount', async () => {
+    renderList();
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/users?id_ne=1');
+    });
+  });
+
+  it('only fetches once on mount (no re-fetch loop)', async () => {
+    renderList();
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+  });
+});
+
+describe('FriendsList — rendering', () => {
+  it('renders the #friendsList container', async () => {
+    const { container } = renderList();
+    await waitFor(() => {
+      expect(container.querySelector('#friendsList')).toBeInTheDocument();
+    });
+  });
+
+  it('renders a Friend item for every user returned', async () => {
+    renderList();
+    await waitFor(() => {
+      expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+      expect(screen.getByText('Bob Jones')).toBeInTheDocument();
+    });
+  });
+
+  it('renders links to each friend\'s page', async () => {
+    renderList();
+    await waitFor(() => {
+      const links = screen.getAllByRole('link');
+      const hrefs = links.map((l) => l.getAttribute('href'));
+      expect(hrefs).toContain('/friend/2');
+      expect(hrefs).toContain('/friend/3');
+    });
+  });
+
+  it('renders an empty container when the API returns no users', async () => {
+    global.fetch.mockResolvedValueOnce({ json: () => Promise.resolve([]) });
+    const { container } = renderList();
+    await waitFor(() => {
+      expect(container.querySelector('#friendsList').children).toHaveLength(0);
+    });
+  });
+});
+
+describe('FriendsList — error handling', () => {
+  it('logs an error and renders an empty list when fetch rejects', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    global.fetch.mockRejectedValueOnce(new Error('Network failure'));
+    const { container } = renderList();
+    await waitFor(() => expect(logSpy).toHaveBeenCalled());
+    expect(container.querySelector('#friendsList').children).toHaveLength(0);
+    logSpy.mockRestore();
+  });
+});

--- a/src/__tests__/components/Post.test.js
+++ b/src/__tests__/components/Post.test.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Post from '../../components/Post';
+
+const mockPost = { _id: 'post1', title: 'Test Title', body: 'Test body content', userId: 'u1' };
+
+function renderPost(props = {}) {
+  return render(
+    <MemoryRouter>
+      <Post post={mockPost} self={true} {...props} />
+    </MemoryRouter>
+  );
+}
+
+describe('Post — content', () => {
+  it('renders the post title', () => {
+    renderPost();
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
+  });
+
+  it('renders the post body', () => {
+    renderPost();
+    expect(screen.getByText('Test body content')).toBeInTheDocument();
+  });
+
+  it("renders today's date in long format", () => {
+    renderPost();
+    const expectedDate = new Date().toLocaleDateString(undefined, {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+    expect(screen.getByText(expectedDate)).toBeInTheDocument();
+  });
+});
+
+describe('Post — edit link', () => {
+  it('the edit link points to /edit/:postId', () => {
+    renderPost({ self: true });
+    const link = screen.getByRole('link', { name: '' }); // link wraps the icon
+    expect(link).toHaveAttribute('href', '/edit/post1');
+  });
+
+  it('the edit icon is visible when self=true (hidden attribute absent)', () => {
+    renderPost({ self: true });
+    const svg = document.querySelector('svg');
+    expect(svg).not.toHaveAttribute('hidden');
+  });
+
+  it('the edit icon is hidden when self=false (hidden attribute present)', () => {
+    renderPost({ self: false });
+    const svg = document.querySelector('svg');
+    expect(svg).toHaveAttribute('hidden');
+  });
+});
+
+describe('Post — card structure', () => {
+  it('wraps content in a card element', () => {
+    const { container } = renderPost();
+    expect(container.querySelector('.card')).toBeInTheDocument();
+  });
+
+  it('places the date in the .postDate span', () => {
+    renderPost();
+    const span = document.querySelector('.postDate');
+    expect(span).toBeInTheDocument();
+    expect(span.textContent).not.toBe('');
+  });
+});

--- a/src/__tests__/components/PostList.test.js
+++ b/src/__tests__/components/PostList.test.js
@@ -1,0 +1,105 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import PostList from '../../components/PostList';
+
+const mockPosts = [
+  { _id: 'p1', title: 'First Post', body: 'Body one', userId: 'u1' },
+  { _id: 'p2', title: 'Second Post', body: 'Body two', userId: 'u1' },
+];
+
+function renderList(props = {}) {
+  return render(
+    <MemoryRouter>
+      <PostList userId="u1" self={true} {...props} />
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ json: () => Promise.resolve(mockPosts) })
+  );
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('PostList — fetching', () => {
+  it('fetches posts for the given userId on mount', async () => {
+    renderList({ userId: 'u1' });
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('api/posts/u1');
+    });
+  });
+
+  it('re-fetches when userId prop changes', async () => {
+    const { rerender } = renderList({ userId: 'u1' });
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith('api/posts/u1'));
+
+    rerender(
+      <MemoryRouter>
+        <PostList userId="u2" self={true} />
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith('api/posts/u2'));
+  });
+});
+
+describe('PostList — rendering', () => {
+  it('renders the #postList container', async () => {
+    const { container } = renderList();
+    await waitFor(() => {
+      expect(container.querySelector('#postList')).toBeInTheDocument();
+    });
+  });
+
+  it('renders a Post card for every post returned by the API', async () => {
+    renderList();
+    await waitFor(() => {
+      expect(screen.getByText('First Post')).toBeInTheDocument();
+      expect(screen.getByText('Second Post')).toBeInTheDocument();
+    });
+  });
+
+  it('renders an empty container when the API returns no posts', async () => {
+    global.fetch.mockResolvedValueOnce({ json: () => Promise.resolve([]) });
+    const { container } = renderList();
+    await waitFor(() => {
+      expect(container.querySelector('#postList').children).toHaveLength(0);
+    });
+  });
+
+  it('passes self=true down so edit icons are shown', async () => {
+    renderList({ self: true });
+    await waitFor(() => {
+      const svgs = document.querySelectorAll('svg');
+      svgs.forEach((svg) => expect(svg).not.toHaveAttribute('hidden'));
+    });
+  });
+
+  it('passes self=false down so edit icons are hidden', async () => {
+    renderList({ self: false });
+    await waitFor(() => {
+      const svgs = document.querySelectorAll('svg');
+      svgs.forEach((svg) => expect(svg).toHaveAttribute('hidden'));
+    });
+  });
+});
+
+describe('PostList — error handling', () => {
+  it('logs an error and renders an empty list when fetch rejects', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    global.fetch.mockRejectedValueOnce(new Error('Network failure'));
+
+    const { container } = renderList();
+    await waitFor(() => {
+      expect(errorSpy).toHaveBeenCalled();
+    });
+    expect(container.querySelector('#postList').children).toHaveLength(0);
+    errorSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+});

--- a/src/__tests__/context/user-context.test.js
+++ b/src/__tests__/context/user-context.test.js
@@ -1,0 +1,124 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { UserProvider, useUserState, useUserDispatch } from '../../context/user-context';
+
+// Renders current state as JSON and exposes dispatch via a ref
+function TestHarness({ stateRef, dispatchRef }) {
+  const state = useUserState();
+  const dispatch = useUserDispatch();
+  if (stateRef) stateRef.current = state;
+  if (dispatchRef) dispatchRef.current = dispatch;
+  return <div data-testid="state">{JSON.stringify(state)}</div>;
+}
+
+const mockUser = { _id: 'u1', firstName: 'Jane', lastName: 'Doe', email: 'jane@x.com', isLoggedIn: true };
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('UserProvider', () => {
+  it('renders children', () => {
+    render(<UserProvider><span>hello</span></UserProvider>);
+    expect(screen.getByText('hello')).toBeInTheDocument();
+  });
+
+  it('provides default unauthenticated user when localStorage is empty', () => {
+    const stateRef = { current: null };
+    render(<UserProvider><TestHarness stateRef={stateRef} /></UserProvider>);
+    expect(stateRef.current.user.isLoggedIn).toBe(false);
+    expect(stateRef.current.user._id).toBe('');
+  });
+
+  it('hydrates state from localStorage on mount', () => {
+    localStorage.setItem('user', JSON.stringify(mockUser));
+    const stateRef = { current: null };
+    render(<UserProvider><TestHarness stateRef={stateRef} /></UserProvider>);
+    expect(stateRef.current.user._id).toBe('u1');
+    expect(stateRef.current.user.isLoggedIn).toBe(true);
+    expect(stateRef.current.user.firstName).toBe('Jane');
+  });
+});
+
+describe('userReducer — set action', () => {
+  it('updates state to the given user payload', () => {
+    const stateRef = { current: null };
+    const dispatchRef = { current: null };
+    render(
+      <UserProvider>
+        <TestHarness stateRef={stateRef} dispatchRef={dispatchRef} />
+      </UserProvider>
+    );
+    act(() => {
+      dispatchRef.current({ type: 'set', payload: mockUser });
+    });
+    expect(stateRef.current.user._id).toBe('u1');
+    expect(stateRef.current.user.firstName).toBe('Jane');
+    expect(stateRef.current.user.isLoggedIn).toBe(true);
+  });
+
+  it('persists the user to localStorage', () => {
+    const dispatchRef = { current: null };
+    render(<UserProvider><TestHarness dispatchRef={dispatchRef} /></UserProvider>);
+    act(() => {
+      dispatchRef.current({ type: 'set', payload: mockUser });
+    });
+    expect(JSON.parse(localStorage.getItem('user'))).toEqual(mockUser);
+  });
+});
+
+describe('userReducer — reset action', () => {
+  it('resets state to the unauthenticated default', () => {
+    localStorage.setItem('user', JSON.stringify(mockUser));
+    const stateRef = { current: null };
+    const dispatchRef = { current: null };
+    render(<UserProvider><TestHarness stateRef={stateRef} dispatchRef={dispatchRef} /></UserProvider>);
+    act(() => {
+      dispatchRef.current({ type: 'reset' });
+    });
+    expect(stateRef.current.user.isLoggedIn).toBe(false);
+    expect(stateRef.current.user._id).toBe('');
+  });
+
+  it('removes user from localStorage', () => {
+    localStorage.setItem('user', JSON.stringify(mockUser));
+    const dispatchRef = { current: null };
+    render(<UserProvider><TestHarness dispatchRef={dispatchRef} /></UserProvider>);
+    act(() => {
+      dispatchRef.current({ type: 'reset' });
+    });
+    expect(localStorage.getItem('user')).toBeNull();
+  });
+});
+
+describe('userReducer — unknown action', () => {
+  it('throws an error for unrecognized action types', () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const dispatchRef = { current: null };
+    render(<UserProvider><TestHarness dispatchRef={dispatchRef} /></UserProvider>);
+    expect(() => {
+      act(() => {
+        dispatchRef.current({ type: 'bogus' });
+      });
+    }).toThrow('Unhandled action type: bogus');
+    consoleSpy.mockRestore();
+  });
+});
+
+describe('useUserState', () => {
+  it('throws when called outside of UserProvider', () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    function Broken() { useUserState(); return null; }
+    expect(() => render(<Broken />)).toThrow('useUserState must be used within a UserProvider');
+    consoleSpy.mockRestore();
+  });
+});
+
+describe('useUserDispatch', () => {
+  it('throws when called outside of UserProvider', () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    function Broken() { useUserDispatch(); return null; }
+    expect(() => render(<Broken />)).toThrow('useUserDispatch must be used within a UserProvider');
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/__tests__/layout/Navbar.test.js
+++ b/src/__tests__/layout/Navbar.test.js
@@ -1,0 +1,130 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import TopNavbar from '../../layout/Navbar';
+import { UserProvider } from '../../context/user-context';
+
+// Mock useNavigate so we can assert navigation without a full router stack
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: jest.fn(),
+}));
+
+import { useNavigate } from 'react-router-dom';
+
+const mockNavigate = jest.fn();
+const loggedInUser = {
+  _id: 'u1',
+  firstName: 'Jane',
+  lastName: 'Doe',
+  email: 'jane@x.com',
+  isLoggedIn: true,
+};
+
+function renderNavbar(user = null) {
+  if (user) {
+    localStorage.setItem('user', JSON.stringify(user));
+  } else {
+    localStorage.removeItem('user');
+  }
+  return render(
+    <MemoryRouter>
+      <UserProvider>
+        <TopNavbar />
+      </UserProvider>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  mockNavigate.mockClear();
+  useNavigate.mockReturnValue(mockNavigate);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('TopNavbar — unauthenticated', () => {
+  it('always renders the Junto brand', () => {
+    renderNavbar();
+    expect(screen.getByText('Junto')).toBeInTheDocument();
+  });
+
+  it('does not show the Friends link', () => {
+    renderNavbar();
+    expect(screen.queryByText('Friends')).not.toBeInTheDocument();
+  });
+
+  it('does not show the Post link', () => {
+    renderNavbar();
+    expect(screen.queryByText('Post')).not.toBeInTheDocument();
+  });
+
+  it('does not show the Logout button', () => {
+    renderNavbar();
+    expect(screen.queryByRole('button', { name: /logout/i })).not.toBeInTheDocument();
+  });
+});
+
+describe('TopNavbar — authenticated', () => {
+  it('displays the logged-in user full name', () => {
+    renderNavbar(loggedInUser);
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument();
+  });
+
+  it('shows the Friends navigation link', () => {
+    renderNavbar(loggedInUser);
+    expect(screen.getByText('Friends')).toBeInTheDocument();
+  });
+
+  it('shows the Post navigation link', () => {
+    renderNavbar(loggedInUser);
+    expect(screen.getByText('Post')).toBeInTheDocument();
+  });
+
+  it('shows the Logout button', () => {
+    renderNavbar(loggedInUser);
+    expect(screen.getByRole('button', { name: /logout/i })).toBeInTheDocument();
+  });
+});
+
+describe('TopNavbar — logout', () => {
+  it('calls POST api/auth/logout when Logout is clicked', async () => {
+    global.fetch = jest.fn(() => Promise.resolve({ status: 200 }));
+    renderNavbar(loggedInUser);
+    fireEvent.click(screen.getByRole('button', { name: /logout/i }));
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('api/auth/logout', { method: 'POST' });
+    });
+  });
+
+  it('navigates to /login after a successful logout', async () => {
+    global.fetch = jest.fn(() => Promise.resolve({ status: 200 }));
+    renderNavbar(loggedInUser);
+    fireEvent.click(screen.getByRole('button', { name: /logout/i }));
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/login');
+    });
+  });
+
+  it('clears user from localStorage after a successful logout', async () => {
+    global.fetch = jest.fn(() => Promise.resolve({ status: 200 }));
+    renderNavbar(loggedInUser);
+    fireEvent.click(screen.getByRole('button', { name: /logout/i }));
+    await waitFor(() => {
+      expect(localStorage.getItem('user')).toBeNull();
+    });
+  });
+
+  it('does not navigate when the server returns a non-200 status', async () => {
+    global.fetch = jest.fn(() => Promise.resolve({ status: 500 }));
+    renderNavbar(loggedInUser);
+    fireEvent.click(screen.getByRole('button', { name: /logout/i }));
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/layout/pages/AddPostPage.test.js
+++ b/src/__tests__/layout/pages/AddPostPage.test.js
@@ -1,0 +1,108 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import AddPostPage from '../../../layout/pages/AddPostPage';
+import { UserProvider } from '../../../context/user-context';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: jest.fn(),
+}));
+
+import { useNavigate } from 'react-router-dom';
+
+const mockNavigate = jest.fn();
+const currentUser = { _id: 'user1', firstName: 'Jane', isLoggedIn: true };
+
+function renderPage() {
+  localStorage.setItem('user', JSON.stringify(currentUser));
+  return render(
+    <MemoryRouter>
+      <UserProvider>
+        <AddPostPage />
+      </UserProvider>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  mockNavigate.mockClear();
+  useNavigate.mockReturnValue(mockNavigate);
+  global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve({}) }));
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('AddPostPage — rendering', () => {
+  it('renders the title input', () => {
+    renderPage();
+    expect(screen.getByPlaceholderText('Title')).toBeInTheDocument();
+  });
+
+  it('renders the body textarea', () => {
+    renderPage();
+    expect(screen.getByPlaceholderText('Body')).toBeInTheDocument();
+  });
+
+  it('renders the Submit button', () => {
+    renderPage();
+    expect(screen.getByRole('button', { name: /submit/i })).toBeInTheDocument();
+  });
+});
+
+describe('AddPostPage — submit button state', () => {
+  it('is disabled when both fields are empty', () => {
+    renderPage();
+    expect(screen.getByRole('button', { name: /submit/i })).toBeDisabled();
+  });
+
+  it('is disabled when only the title is filled', () => {
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'A title' } });
+    expect(screen.getByRole('button', { name: /submit/i })).toBeDisabled();
+  });
+
+  it('is disabled when only the body is filled', () => {
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText('Body'), { target: { value: 'Some body' } });
+    expect(screen.getByRole('button', { name: /submit/i })).toBeDisabled();
+  });
+
+  it('is enabled when both title and body have content', () => {
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'A title' } });
+    fireEvent.change(screen.getByPlaceholderText('Body'), { target: { value: 'Some body' } });
+    expect(screen.getByRole('button', { name: /submit/i })).not.toBeDisabled();
+  });
+});
+
+describe('AddPostPage — form submission', () => {
+  it('posts to /api/posts with the correct payload', async () => {
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'My Title' } });
+    fireEvent.change(screen.getByPlaceholderText('Body'), { target: { value: 'My Body' } });
+    fireEvent.submit(screen.getByRole('button', { name: /submit/i }).closest('form'));
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/posts',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ title: 'My Title', body: 'My Body', userId: 'user1' }),
+        })
+      );
+    });
+  });
+
+  it('navigates to / after a successful post', async () => {
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'My Title' } });
+    fireEvent.change(screen.getByPlaceholderText('Body'), { target: { value: 'My Body' } });
+    fireEvent.submit(screen.getByRole('button', { name: /submit/i }).closest('form'));
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+  });
+});

--- a/src/__tests__/layout/pages/EditPostPage.test.js
+++ b/src/__tests__/layout/pages/EditPostPage.test.js
@@ -1,0 +1,150 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import EditPostPage from '../../../layout/pages/EditPostPage';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: jest.fn(),
+}));
+
+import { useNavigate } from 'react-router-dom';
+
+const mockNavigate = jest.fn();
+const mockPost = { _id: 'post1', title: 'Old Title', body: 'Old Body', userId: 'user1' };
+
+// Renders EditPostPage at /edit/:postId with location state containing the post
+function renderPage(post = mockPost) {
+  return render(
+    <MemoryRouter initialEntries={[{ pathname: '/edit/post1', state: { post } }]}>
+      <Routes>
+        <Route path="/edit/:postId" element={<EditPostPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  mockNavigate.mockClear();
+  useNavigate.mockReturnValue(mockNavigate);
+  global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve({}) }));
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('EditPostPage — rendering', () => {
+  it('pre-fills the title input from location state', () => {
+    renderPage();
+    expect(screen.getByDisplayValue('Old Title')).toBeInTheDocument();
+  });
+
+  it('pre-fills the body textarea from location state', () => {
+    renderPage();
+    expect(screen.getByDisplayValue('Old Body')).toBeInTheDocument();
+  });
+
+  it('renders the Save button', () => {
+    renderPage();
+    expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
+  });
+
+  it('renders the Delete button', () => {
+    renderPage();
+    expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
+  });
+
+  it('initialises title and body to empty strings when post is falsy', () => {
+    // location state has no post (null state.post)
+    render(
+      <MemoryRouter initialEntries={[{ pathname: '/edit/post1', state: { post: null } }]}>
+        <Routes>
+          <Route path="/edit/:postId" element={<EditPostPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByPlaceholderText('Title')).toHaveValue('');
+    expect(screen.getByPlaceholderText('Body')).toHaveValue('');
+  });
+});
+
+describe('EditPostPage — Save button state', () => {
+  it('is disabled when the title is cleared', () => {
+    renderPage();
+    fireEvent.change(screen.getByDisplayValue('Old Title'), { target: { value: '' } });
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+  });
+
+  it('is disabled when the body is cleared', () => {
+    renderPage();
+    fireEvent.change(screen.getByDisplayValue('Old Body'), { target: { value: '' } });
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+  });
+
+  it('is enabled when both fields have content', () => {
+    renderPage();
+    expect(screen.getByRole('button', { name: /save/i })).not.toBeDisabled();
+  });
+});
+
+describe('EditPostPage — saving a post', () => {
+  it('sends a PUT request to /api/posts with the updated payload', async () => {
+    renderPage();
+    fireEvent.change(screen.getByDisplayValue('Old Title'), { target: { value: 'New Title' } });
+    fireEvent.change(screen.getByDisplayValue('Old Body'), { target: { value: 'New Body' } });
+    fireEvent.submit(screen.getByRole('button', { name: /save/i }).closest('form'));
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/posts',
+        expect.objectContaining({
+          method: 'PUT',
+          body: JSON.stringify({
+            _id: 'post1',
+            userId: 'user1',
+            title: 'New Title',
+            body: 'New Body',
+          }),
+        })
+      );
+    });
+  });
+
+  it('navigates to / after saving', async () => {
+    renderPage();
+    fireEvent.submit(screen.getByRole('button', { name: /save/i }).closest('form'));
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+  });
+});
+
+describe('EditPostPage — deleting a post', () => {
+  it('sends a DELETE request for the correct postId', async () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/api/posts/delete/post1', { method: 'DELETE' });
+    });
+  });
+
+  it('navigates to / after deletion', async () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('does not fire the PUT (save) request when Delete is clicked', async () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    // Only one fetch call (DELETE), not two
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/posts/delete/'),
+      expect.anything()
+    );
+  });
+});

--- a/src/__tests__/layout/pages/ErrorPage.test.js
+++ b/src/__tests__/layout/pages/ErrorPage.test.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ErrorPage from '../../../layout/pages/ErrorPage';
+
+describe('ErrorPage', () => {
+  it('renders the 404 heading', () => {
+    render(<ErrorPage />);
+    expect(screen.getByRole('heading', { name: /oops! page not found!/i })).toBeInTheDocument();
+  });
+
+  it('heading is an h1', () => {
+    const { container } = render(<ErrorPage />);
+    expect(container.querySelector('h1')).toHaveTextContent('Oops! Page not found!');
+  });
+});

--- a/src/__tests__/layout/pages/FriendsListPage.test.js
+++ b/src/__tests__/layout/pages/FriendsListPage.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import FriendsListPage from '../../../layout/pages/FriendsListPage';
+
+beforeEach(() => {
+  global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve([]) }));
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('FriendsListPage', () => {
+  it('renders the friends list container', async () => {
+    const { container } = render(
+      <MemoryRouter>
+        <FriendsListPage />
+      </MemoryRouter>
+    );
+    await waitFor(() => {
+      expect(container.querySelector('#friendsList')).toBeInTheDocument();
+    });
+  });
+
+  it('delegates to FriendsList which fetches users on mount', async () => {
+    render(
+      <MemoryRouter>
+        <FriendsListPage />
+      </MemoryRouter>
+    );
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/users?id_ne=1');
+    });
+  });
+});

--- a/src/__tests__/layout/pages/FriendsPage.test.js
+++ b/src/__tests__/layout/pages/FriendsPage.test.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import FriendsPage from '../../../layout/pages/FriendsPage';
+
+beforeEach(() => {
+  global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve([]) }));
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+function renderPage(userId = 'friend42') {
+  return render(
+    <MemoryRouter initialEntries={[`/friends/${userId}`]}>
+      <Routes>
+        <Route path="/friends/:userId" element={<FriendsPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('FriendsPage', () => {
+  it('renders the post list container', async () => {
+    const { container } = renderPage();
+    await waitFor(() => {
+      expect(container.querySelector('#postList')).toBeInTheDocument();
+    });
+  });
+
+  it('fetches posts for the userId in the URL param', async () => {
+    renderPage('friend42');
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('api/posts/friend42');
+    });
+  });
+
+  it('fetches posts for a different userId when the param changes', async () => {
+    renderPage('abc123');
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('api/posts/abc123');
+    });
+  });
+
+  it('does not show edit controls (self=false)', async () => {
+    const posts = [{ _id: 'p1', title: 'Post', body: 'Body', userId: 'friend42' }];
+    global.fetch.mockResolvedValueOnce({ json: () => Promise.resolve(posts) });
+    const { container } = renderPage('friend42');
+    await waitFor(() => {
+      const icon = container.querySelector('svg');
+      // hidden prop set to true when self=false
+      expect(icon).toHaveAttribute('hidden');
+    });
+  });
+});

--- a/src/__tests__/layout/pages/HomePage.test.js
+++ b/src/__tests__/layout/pages/HomePage.test.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import HomePage from '../../../layout/pages/HomePage';
+import { UserProvider } from '../../../context/user-context';
+
+const currentUser = { _id: 'user123', firstName: 'Jane', isLoggedIn: true };
+
+beforeEach(() => {
+  localStorage.setItem('user', JSON.stringify(currentUser));
+  global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve([]) }));
+});
+
+afterEach(() => {
+  localStorage.clear();
+  jest.restoreAllMocks();
+});
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <UserProvider>
+        <HomePage />
+      </UserProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('HomePage', () => {
+  it('renders the post list container', async () => {
+    const { container } = renderPage();
+    await waitFor(() => {
+      expect(container.querySelector('#postList')).toBeInTheDocument();
+    });
+  });
+
+  it('fetches posts for the currently logged-in user', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('api/posts/user123');
+    });
+  });
+
+  it('passes self=true to PostList so edit controls are visible', async () => {
+    const posts = [{ _id: 'p1', title: 'My Post', body: 'Body', userId: 'user123' }];
+    global.fetch.mockResolvedValueOnce({ json: () => Promise.resolve(posts) });
+    const { container } = renderPage();
+    await waitFor(() => {
+      // The edit icon link is rendered (self=true means hidden=false on the icon)
+      const editLinks = container.querySelectorAll('.editPostBtn');
+      expect(editLinks.length).toBe(1);
+    });
+  });
+});

--- a/src/__tests__/layout/pages/LoginPage.test.js
+++ b/src/__tests__/layout/pages/LoginPage.test.js
@@ -1,0 +1,159 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import LoginPage from '../../../layout/pages/LoginPage';
+import { UserProvider } from '../../../context/user-context';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: jest.fn(),
+}));
+
+import { useNavigate } from 'react-router-dom';
+
+const mockNavigate = jest.fn();
+
+function renderPage() {
+  localStorage.clear();
+  return render(
+    <MemoryRouter>
+      <UserProvider>
+        <LoginPage />
+      </UserProvider>
+    </MemoryRouter>
+  );
+}
+
+// Workaround: JSDOM v16 (bundled with react-scripts 5 / jest 27) does not update the
+// form.elements collection when name attributes are set dynamically, so form['email']
+// returns undefined. Assigning the elements as own properties on the form element lets
+// the handler's event.target.email / event.target.password lookups succeed.
+function submitForm() {
+  const form = screen.getByRole('button', { name: /submit/i }).closest('form');
+  Object.assign(form, {
+    email: screen.getByPlaceholderText('User Email'),
+    password: screen.getByPlaceholderText('Password'),
+  });
+  fireEvent.submit(form);
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  mockNavigate.mockClear();
+  useNavigate.mockReturnValue(mockNavigate);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('LoginPage — rendering', () => {
+  it('renders the Login heading', () => {
+    renderPage();
+    expect(screen.getByRole('heading', { name: /login/i })).toBeInTheDocument();
+  });
+
+  it('renders the email input', () => {
+    renderPage();
+    expect(screen.getByPlaceholderText('User Email')).toBeInTheDocument();
+  });
+
+  it('renders the password input', () => {
+    renderPage();
+    expect(screen.getByPlaceholderText('Password')).toBeInTheDocument();
+  });
+
+  it('renders the Submit button', () => {
+    renderPage();
+    expect(screen.getByRole('button', { name: /submit/i })).toBeInTheDocument();
+  });
+
+  it('shows a link to the register page', () => {
+    renderPage();
+    const link = screen.getByText('New user?').closest('a');
+    expect(link).toHaveAttribute('href', '/register');
+  });
+});
+
+describe('LoginPage — successful login', () => {
+  const serverUser = { _id: 'u1', firstName: 'Jane', lastName: 'Doe', email: 'jane@x.com' };
+
+  beforeEach(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ status: 200, json: () => Promise.resolve(serverUser) })
+    );
+  });
+
+  it('posts credentials to /api/auth with email and password', async () => {
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText('User Email'), {
+      target: { value: 'jane@x.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'secret' } });
+    submitForm();
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/auth',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ email: 'jane@x.com', password: 'secret' }),
+        })
+      );
+    });
+  });
+
+  it('navigates to / on success', async () => {
+    renderPage();
+    submitForm();
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('stores the user in localStorage with isLoggedIn=true on success', async () => {
+    renderPage();
+    submitForm();
+    await waitFor(() => {
+      const stored = JSON.parse(localStorage.getItem('user'));
+      expect(stored.isLoggedIn).toBe(true);
+      expect(stored._id).toBe('u1');
+    });
+  });
+});
+
+describe('LoginPage — failed login', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() => Promise.resolve({ status: 401 }));
+  });
+
+  it('shows "Invalid Email or Password" on a non-200 response', async () => {
+    renderPage();
+    submitForm();
+    await waitFor(() => {
+      expect(screen.getByText('Invalid Email or Password')).toBeInTheDocument();
+    });
+  });
+
+  it('does not navigate on failure', async () => {
+    renderPage();
+    submitForm();
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('clears the error message after a subsequent successful login', async () => {
+    const serverUser = { _id: 'u1', firstName: 'Jane', lastName: 'Doe', email: 'jane@x.com' };
+    global.fetch
+      .mockResolvedValueOnce({ status: 401 })
+      .mockResolvedValueOnce({ status: 200, json: () => Promise.resolve(serverUser) });
+
+    renderPage();
+    submitForm();
+    await waitFor(() => expect(screen.getByText('Invalid Email or Password')).toBeInTheDocument());
+
+    submitForm();
+    await waitFor(() =>
+      expect(screen.queryByText('Invalid Email or Password')).not.toBeInTheDocument()
+    );
+  });
+});

--- a/src/__tests__/layout/pages/UserCreationPage.test.js
+++ b/src/__tests__/layout/pages/UserCreationPage.test.js
@@ -1,0 +1,254 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import UserCreationPage from '../../../layout/pages/UserCreationPage';
+import { UserProvider } from '../../../context/user-context';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: jest.fn(),
+}));
+
+import { useNavigate } from 'react-router-dom';
+
+const mockNavigate = jest.fn();
+
+function renderPage() {
+  localStorage.clear();
+  return render(
+    <MemoryRouter>
+      <UserProvider>
+        <UserCreationPage />
+      </UserProvider>
+    </MemoryRouter>
+  );
+}
+
+// Fill every field; callers can override individual values to trigger validation errors.
+function fillForm({
+  firstName = 'Jane',
+  lastName = 'Doe',
+  email = 'jane@example.com',
+  password = 'password',
+  confirmPassword = 'password',
+} = {}) {
+  fireEvent.change(screen.getByPlaceholderText('First Name'), { target: { value: firstName } });
+  fireEvent.change(screen.getByPlaceholderText('Last Name'), { target: { value: lastName } });
+  fireEvent.change(screen.getByPlaceholderText('Email'), { target: { value: email } });
+  fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: password } });
+  fireEvent.change(screen.getByPlaceholderText('Confirm Password'), {
+    target: { value: confirmPassword },
+  });
+}
+
+// Workaround: JSDOM v16 (bundled with react-scripts 5 / jest 27) does not update the
+// form.elements collection when name attributes are set dynamically. Assigning the
+// input elements as own properties on the form lets the handler's event.target.fieldName
+// lookups succeed without modifying the production source code.
+function submit() {
+  const form = screen.getByRole('button', { name: /submit/i }).closest('form');
+  Object.assign(form, {
+    firstName: screen.getByPlaceholderText('First Name'),
+    lastName: screen.getByPlaceholderText('Last Name'),
+    email: screen.getByPlaceholderText('Email'),
+    password: screen.getByPlaceholderText('Password'),
+    confirmPassword: screen.getByPlaceholderText('Confirm Password'),
+  });
+  fireEvent.submit(form);
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  mockNavigate.mockClear();
+  useNavigate.mockReturnValue(mockNavigate);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('UserCreationPage — rendering', () => {
+  it('renders the Create User heading', () => {
+    renderPage();
+    expect(screen.getByRole('heading', { name: /create user/i })).toBeInTheDocument();
+  });
+
+  it('renders all five form fields', () => {
+    renderPage();
+    expect(screen.getByPlaceholderText('First Name')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Last Name')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Email')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Password')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Confirm Password')).toBeInTheDocument();
+  });
+
+  it('shows a link back to the login page', () => {
+    renderPage();
+    expect(screen.getByText('Already a user?').closest('a')).toHaveAttribute('href', '/login');
+  });
+});
+
+describe('UserCreationPage — validation', () => {
+  it('shows an error when first name is too short (< 2 chars)', async () => {
+    renderPage();
+    fillForm({ firstName: 'J' });
+    submit();
+    await waitFor(() => {
+      expect(screen.getByText('First Name must be longer than 1 character')).toBeInTheDocument();
+    });
+  });
+
+  it('shows an error when last name is too short (< 2 chars)', async () => {
+    renderPage();
+    fillForm({ lastName: 'D' });
+    submit();
+    await waitFor(() => {
+      expect(screen.getByText('Last Name must be longer than 1 character')).toBeInTheDocument();
+    });
+  });
+
+  it('shows an error when email is too short (< 6 chars)', async () => {
+    renderPage();
+    fillForm({ email: 'a@b' }); // 3 chars
+    submit();
+    await waitFor(() => {
+      expect(screen.getByText('Email must be longer than 5 characters')).toBeInTheDocument();
+    });
+  });
+
+  it('shows an error when password is too short (< 6 chars)', async () => {
+    renderPage();
+    fillForm({ password: 'abc', confirmPassword: 'abc' });
+    submit();
+    await waitFor(() => {
+      expect(screen.getByText('Password must be longer than 5 characters')).toBeInTheDocument();
+    });
+  });
+
+  it('shows an error when password is too long (> 255 chars)', async () => {
+    renderPage();
+    const longPassword = 'a'.repeat(256);
+    fillForm({ password: longPassword, confirmPassword: longPassword });
+    submit();
+    await waitFor(() => {
+      expect(screen.getByText('Password must be less than 256 characters')).toBeInTheDocument();
+    });
+  });
+
+  it('shows an error when confirm password does not match', async () => {
+    renderPage();
+    fillForm({ password: 'password1', confirmPassword: 'password2' });
+    submit();
+    await waitFor(() => {
+      expect(screen.getByText('Confirm Password does not match Password')).toBeInTheDocument();
+    });
+  });
+
+  it('does not submit when validation fails', async () => {
+    global.fetch = jest.fn();
+    renderPage();
+    fillForm({ firstName: 'J' }); // invalid
+    submit();
+    await waitFor(() =>
+      expect(screen.getByText('First Name must be longer than 1 character')).toBeInTheDocument()
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('UserCreationPage — successful registration', () => {
+  const serverUser = { _id: 'u1', firstName: 'Jane', lastName: 'Doe', email: 'jane@example.com' };
+
+  beforeEach(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ status: 200, json: () => Promise.resolve(serverUser) })
+    );
+  });
+
+  it('posts user data to /api/users', async () => {
+    renderPage();
+    fillForm();
+    submit();
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/users',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            firstName: 'Jane',
+            lastName: 'Doe',
+            email: 'jane@example.com',
+            password: 'password',
+          }),
+        })
+      );
+    });
+  });
+
+  it('navigates to / on success', async () => {
+    renderPage();
+    fillForm();
+    submit();
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('stores the user in context/localStorage on success', async () => {
+    renderPage();
+    fillForm();
+    submit();
+    await waitFor(() => {
+      const stored = JSON.parse(localStorage.getItem('user'));
+      expect(stored._id).toBe('u1');
+    });
+  });
+});
+
+describe('UserCreationPage — server errors', () => {
+  it('shows "email already in use" message on status 400', async () => {
+    global.fetch = jest.fn(() => Promise.resolve({ status: 400 }));
+    renderPage();
+    fillForm();
+    submit();
+    await waitFor(() => {
+      // Matches the exact (typo-inclusive) string from the source
+      expect(
+        screen.getByText('Email is already in use. Use a diffrent email.')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows a generic error message on network failure', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    global.fetch = jest.fn(() => Promise.reject(new Error('Network Error')));
+    renderPage();
+    fillForm();
+    submit();
+    await waitFor(() => {
+      expect(
+        screen.getByText('Could not create new user. Please try again.')
+      ).toBeInTheDocument();
+    });
+    consoleSpy.mockRestore();
+  });
+
+  it('shows a generic error on an unexpected status code', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        status: 500,
+        json: () => { throw new Error('There was a network error on submitting new user.'); },
+      })
+    );
+    renderPage();
+    fillForm();
+    submit();
+    await waitFor(() => {
+      expect(
+        screen.getByText('Could not create new user. Please try again.')
+      ).toBeInTheDocument();
+    });
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/__tests__/routes/PrivateRoute.test.js
+++ b/src/__tests__/routes/PrivateRoute.test.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import PrivateRoute from '../../routes/PrivateRoute';
+import { UserProvider } from '../../context/user-context';
+
+function renderRoute(user = null) {
+  if (user) {
+    localStorage.setItem('user', JSON.stringify(user));
+  } else {
+    localStorage.removeItem('user');
+  }
+  return render(
+    <MemoryRouter initialEntries={['/protected']}>
+      <UserProvider>
+        <Routes>
+          <Route
+            path="/protected"
+            element={
+              <PrivateRoute>
+                <div>Protected Content</div>
+              </PrivateRoute>
+            }
+          />
+          <Route path="/login" element={<div>Login Page</div>} />
+        </Routes>
+      </UserProvider>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('PrivateRoute', () => {
+  it('renders children when the user is logged in', () => {
+    renderRoute({ _id: 'u1', isLoggedIn: true });
+    expect(screen.getByText('Protected Content')).toBeInTheDocument();
+    expect(screen.queryByText('Login Page')).not.toBeInTheDocument();
+  });
+
+  it('redirects to /login when there is no authenticated user', () => {
+    renderRoute();
+    expect(screen.getByText('Login Page')).toBeInTheDocument();
+    expect(screen.queryByText('Protected Content')).not.toBeInTheDocument();
+  });
+
+  it('redirects to /login when isLoggedIn is explicitly false', () => {
+    renderRoute({ _id: 'u1', isLoggedIn: false });
+    expect(screen.getByText('Login Page')).toBeInTheDocument();
+    expect(screen.queryByText('Protected Content')).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/routes/PublicRoute.test.js
+++ b/src/__tests__/routes/PublicRoute.test.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import PublicRoute from '../../routes/PublicRoute';
+import { UserProvider } from '../../context/user-context';
+
+function renderRoute({ user = null, restricted = false } = {}) {
+  if (user) {
+    localStorage.setItem('user', JSON.stringify(user));
+  } else {
+    localStorage.removeItem('user');
+  }
+  return render(
+    <MemoryRouter initialEntries={['/public']}>
+      <UserProvider>
+        <Routes>
+          <Route
+            path="/public"
+            element={
+              <PublicRoute restricted={restricted}>
+                <div>Public Content</div>
+              </PublicRoute>
+            }
+          />
+          <Route path="/" element={<div>Home Page</div>} />
+        </Routes>
+      </UserProvider>
+    </MemoryRouter>
+  );
+}
+
+const loggedInUser = { _id: 'u1', isLoggedIn: true };
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('PublicRoute', () => {
+  it('renders children when user is not logged in and route is restricted', () => {
+    renderRoute({ restricted: true });
+    expect(screen.getByText('Public Content')).toBeInTheDocument();
+    expect(screen.queryByText('Home Page')).not.toBeInTheDocument();
+  });
+
+  it('renders children when user is not logged in and route is unrestricted', () => {
+    renderRoute({ restricted: false });
+    expect(screen.getByText('Public Content')).toBeInTheDocument();
+  });
+
+  it('redirects to / when user is logged in and route is restricted', () => {
+    renderRoute({ user: loggedInUser, restricted: true });
+    expect(screen.getByText('Home Page')).toBeInTheDocument();
+    expect(screen.queryByText('Public Content')).not.toBeInTheDocument();
+  });
+
+  it('renders children when user is logged in but route is unrestricted', () => {
+    renderRoute({ user: loggedInUser, restricted: false });
+    expect(screen.getByText('Public Content')).toBeInTheDocument();
+    expect(screen.queryByText('Home Page')).not.toBeInTheDocument();
+  });
+});

--- a/src/tests/Post.test.js
+++ b/src/tests/Post.test.js
@@ -1,3 +1,2 @@
-describe("Post component", () => {
-  it("should do something", () => {});
-});
+// Post component tests live in src/__tests__/components/Post.test.js
+test.todo('Post component tests are in src/__tests__/components/Post.test.js');


### PR DESCRIPTION
Creates src/__tests__/ with 16 test files covering context, routes, layout, pages, and components. 118 tests pass across 17 suites.

Key decisions:
- UserProvider reducer (set/reset/unknown), localStorage persistence, and hook guard throws are tested via a lightweight TestHarness component
- PrivateRoute and PublicRoute are tested end-to-end with MemoryRouter + Routes so actual navigation/redirect behaviour is verified
- useNavigate is mocked via jest.mock so navigation assertions don't require a full router stack
- fetch is mocked with jest.fn() in beforeEach; console spies suppress expected error output in error-path tests
- JSDOM v16 (jest 27 / react-scripts 5) does not update form.elements when name attributes are added dynamically; LoginPage and UserCreationPage tests use Object.assign(form, {field: input}) to expose named properties to the submit handler without touching production code
- src/tests/Post.test.js placeholder replaced with test.todo pointing to the new location